### PR TITLE
update scripting

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -15,8 +15,10 @@ dependencies {
     implementation project(':core')
     implementation project(':fmi')
     implementation project(':chart')
-    implementation project(':threekt-render')
+    runtimeOnly project(':threekt-render')
     implementation project(':scenario-scripting')
+
+    implementation 'info.laht.kts:host:0.4.0'
 
     implementation group: 'info.picocli', name: 'picocli', version: '4.5.0'
 

--- a/cli/src/main/kotlin/no/ntnu/ihb/vico/cli/VicoCLI.kt
+++ b/cli/src/main/kotlin/no/ntnu/ihb/vico/cli/VicoCLI.kt
@@ -1,12 +1,13 @@
 package no.ntnu.ihb.vico.cli
 
 import no.ntnu.ihb.vico.Vico
+import no.ntnu.ihb.vico.cli.commands.Eval
 import no.ntnu.ihb.vico.cli.commands.SimulateFmu
 import no.ntnu.ihb.vico.cli.commands.SimulateSsp
 import picocli.CommandLine
 
 @CommandLine.Command(
-        subcommands = [SimulateFmu::class, SimulateSsp::class]
+    subcommands = [SimulateFmu::class, SimulateSsp::class, Eval::class]
 )
 class VicoCLI : Runnable {
 

--- a/cli/src/main/kotlin/no/ntnu/ihb/vico/cli/commands/Eval.kt
+++ b/cli/src/main/kotlin/no/ntnu/ihb/vico/cli/commands/Eval.kt
@@ -1,0 +1,33 @@
+package no.ntnu.ihb.vico.cli.commands
+
+import info.laht.kts.KtsScriptRunner
+import picocli.CommandLine
+import java.io.File
+import java.net.URLClassLoader
+import kotlin.concurrent.thread
+
+@CommandLine.Command(name = "eval", description = ["Evaluate kotlin script"])
+class Eval : Runnable {
+
+    @CommandLine.Parameters(
+        arity = "1",
+        paramLabel = "SCRIPT",
+        description = ["Path to the script to evaluate"]
+    )
+    private lateinit var script: File
+
+    override fun run() {
+
+        require(script.exists())
+        require(script.extension == "kts")
+
+        val cacheDir = File(".kts").apply { mkdir() }
+        thread(true, contextClassLoader = URLClassLoader(arrayOf(), null)) {
+            KtsScriptRunner(cacheDir).eval(script)?.also { result ->
+                println(result)
+            }
+        }
+
+    }
+
+}

--- a/cli/src/main/kotlin/no/ntnu/ihb/vico/cli/commands/SimulateSsp.kt
+++ b/cli/src/main/kotlin/no/ntnu/ihb/vico/cli/commands/SimulateSsp.kt
@@ -1,10 +1,10 @@
 package no.ntnu.ihb.vico.cli.commands
 
-import info.laht.krender.threekt.ThreektRenderer
 import no.ntnu.ihb.vico.chart.ChartLoader
 import no.ntnu.ihb.vico.core.Engine
 import no.ntnu.ihb.vico.log.SlaveLoggerSystem
 import no.ntnu.ihb.vico.master.FixedStepMaster
+import no.ntnu.ihb.vico.render.RenderEngine
 import no.ntnu.ihb.vico.render.TVisualConfig
 import no.ntnu.ihb.vico.render.VisualLoader
 import no.ntnu.ihb.vico.scenario.parseScenario
@@ -121,7 +121,8 @@ class SimulateSsp : Runnable {
         }
 
         val renderer = visualConfig?.let {
-            ThreektRenderer().apply {
+            val cls = ClassLoader.getSystemClassLoader().loadClass("info.laht.krender.threekt.ThreektRenderer")
+            (cls.newInstance() as RenderEngine).apply {
                 setCameraTransform(Matrix4f().setTranslation(50f, 50f, 50f))
             }
         }
@@ -161,7 +162,9 @@ class SimulateSsp : Runnable {
                     var configFile = getConfigPath(loader.ssdFile.parentFile, configPath)
                     if (!configFile.exists()) configFile = File(configPath).absoluteFile
                     if (!configFile.exists()) throw NoSuchFileException(configFile)
-                    val scenario = parseScenario(configFile) ?: throw RuntimeException("Failed to load scenario!")
+                    val cacheDir = File(".kts").apply { mkdirs() }
+                    val scenario = parseScenario(configFile, cacheDir)
+                        ?: throw RuntimeException("Failed to load scenario!")
                     scenario.applyScenario(engine)
                 }
 

--- a/scenario-scripting/build.gradle
+++ b/scenario-scripting/build.gradle
@@ -6,8 +6,7 @@ dependencies {
 
     implementation project(':core')
 
-    runtimeOnly 'org.jetbrains.kotlin:kotlin-main-kts'
-    runtimeOnly 'org.jetbrains.kotlin:kotlin-scripting-jsr223'
+    implementation 'info.laht.kts:host:0.4.0'
 
     testImplementation project(':test-data')
     

--- a/scenario-scripting/src/main/kotlin/no/ntnu/ihb/vico/scenario/scripting.kt
+++ b/scenario-scripting/src/main/kotlin/no/ntnu/ihb/vico/scenario/scripting.kt
@@ -1,37 +1,25 @@
 package no.ntnu.ihb.vico.scenario
 
+import info.laht.kts.KtsScriptRunner
 import no.ntnu.ihb.vico.dsl.ScenarioContext
 import java.io.File
-import java.util.concurrent.atomic.AtomicBoolean
-import javax.script.ScriptEngineManager
 
-private val isEnvironmentSetup = AtomicBoolean(false)
-
-private val scriptEngine
-    get() = ScriptEngineManager().getEngineByExtension("main.kts")
-
-
-private fun setupScriptingEnvironment() {
-    if (!isEnvironmentSetup.getAndSet(true)) {
-        System.setProperty("idea.io.use.nio2", "true")
-    }
-}
-
-fun parseScenario(scriptFile: File): ScenarioContext? {
-    return parseScenario(scriptFile.readText())
-}
-
-fun parseScenario(script: String): ScenarioContext? {
-
-    setupScriptingEnvironment()
-
+@JvmOverloads
+fun parseScenario(scriptFile: File, cacheDir: File? = null): ScenarioContext? {
     return try {
-        scriptEngine.let {
-            it.eval(script) as ScenarioContext
-        }
+        KtsScriptRunner(cacheDir).eval(scriptFile) as ScenarioContext?
     } catch (ex: Exception) {
         ex.printStackTrace()
         null
     }
+}
 
+@JvmOverloads
+fun parseScenario(script: String, cacheDir: File? = null): ScenarioContext? {
+    return try {
+        KtsScriptRunner(cacheDir).eval(script) as ScenarioContext?
+    } catch (ex: Exception) {
+        ex.printStackTrace()
+        null
+    }
 }

--- a/scenario-scripting/src/test/kotlin/no/ntnu/ihb/vico/scenario/TestScenarioScript.kt
+++ b/scenario-scripting/src/test/kotlin/no/ntnu/ihb/vico/scenario/TestScenarioScript.kt
@@ -9,26 +9,9 @@ internal class TestScenarioScript {
     @Test
     fun testInline() {
 
-        val scenario = """
-
-            import no.ntnu.ihb.vico.dsl.*
-
-            scenario {
-            
-                invokeAt(1.0) {
-                    println("Hello from script")
-                }
-            
-            }
-            
-        """.trimIndent()
-
         EngineBuilder().build().use { engine ->
-
-            parseScenario(scenario)?.applyScenario(engine)
-
+            parseScenario(scenarioText)?.applyScenario(engine)
             engine.stepUntil(2.0)
-
         }
 
     }
@@ -36,16 +19,17 @@ internal class TestScenarioScript {
     @Test
     fun testFile() {
 
-        val scenario = File(javaClass.classLoader.getResource("scenario/testScenario.main.kts")!!.file)
-
         EngineBuilder().build().use { engine ->
-
-            parseScenario(scenario)?.applyScenario(engine)
-
+            parseScenario(scenarioFile)?.applyScenario(engine)
             engine.stepUntil(2.0)
-
         }
 
+    }
+
+    private companion object {
+        private val cl = TestScenarioScript::class.java.classLoader
+        val scenarioFile = File(cl.getResource("scenario/testScenario.main.kts")!!.file)
+        val scenarioText by lazy { scenarioFile.readText() }
     }
 
 }

--- a/scenario-scripting/src/test/resources/scenario/testScenario.main.kts
+++ b/scenario-scripting/src/test/resources/scenario/testScenario.main.kts
@@ -1,5 +1,5 @@
 @file:Repository("https://dl.bintray.com/ntnu-ihb/mvn")
-@file:DependsOn("no.ntnu.ihb.vico:core:0.2.0")
+@file:DependsOn("no.ntnu.ihb.vico:core:0.3.3")
 
 import no.ntnu.ihb.vico.dsl.scenario
 


### PR DESCRIPTION
Use kts::host for the purpose of evaluating kotlin scripts.

Adds vico eval command to evaluate generic Kotlin scripts using kts::host. This is needed in order to easily have a way of running complex Vico simulation defined through generic Kotlin scripts, as kotlin-main-kts has some limitations